### PR TITLE
Add option for pill shape in custom frame settings.

### DIFF
--- a/src/ShowyEdge/swift/Extensions/ConditionalModifier.swift
+++ b/src/ShowyEdge/swift/Extensions/ConditionalModifier.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/src/ShowyEdge/swift/UserSettings.swift
+++ b/src/ShowyEdge/swift/UserSettings.swift
@@ -286,4 +286,17 @@ final class UserSettings: ObservableObject {
             )
         }
     }
+
+    @UserDefault("kCustomFramePillShape", defaultValue: false)
+    var customFramePillShape: Bool {
+        willSet {
+            objectWillChange.send()
+        }
+        didSet {
+            NotificationCenter.default.post(
+                name: UserSettings.indicatorConfigurationChanged,
+                object: nil
+            )
+        }
+    }
 }

--- a/src/ShowyEdge/swift/Views/IndicatorView.swift
+++ b/src/ShowyEdge/swift/Views/IndicatorView.swift
@@ -6,7 +6,7 @@ struct IndicatorView: View {
 
     var body: some View {
         GeometryReader { metrics in
-            if self.userSettings.colorsLayoutOrientation == "horizontal" {
+            if userSettings.colorsLayoutOrientation == "horizontal" {
                 HStack(spacing: 0) {
                     Rectangle().fill(self.indicatorColors.colors.0).frame(width: metrics.size.width / 3)
                     Rectangle().fill(self.indicatorColors.colors.1).frame(width: metrics.size.width / 3)
@@ -19,6 +19,9 @@ struct IndicatorView: View {
                     Rectangle().fill(self.indicatorColors.colors.2).frame(height: metrics.size.height / 3)
                 }
             }
+        }
+        .if(userSettings.useCustomFrame && userSettings.customFramePillShape) {
+            $0.clipShape(Capsule())
         }
     }
 }

--- a/src/ShowyEdge/swift/Views/PreferencesCustomFrameView.swift
+++ b/src/ShowyEdge/swift/Views/PreferencesCustomFrameView.swift
@@ -11,67 +11,84 @@ struct PreferencesCustomFrameView: View {
                         Text("Use custom frame (Default: off)")
                     }
 
-                    GroupBox(label: Text("Size")) {
-                        HStack {
-                            Text("Width")
-
-                            DoubleTextField(value: $userSettings.customFrameWidth,
-                                            range: 0 ... 10000,
-                                            step: 10,
-                                            width: 50)
-
-                            CustomFrameUnitPicker(value: $userSettings.customFrameWidthUnit)
-
-                            Text("Height").padding(.leading, 40)
-
-                            DoubleTextField(value: $userSettings.customFrameHeight,
-                                            range: 0 ... 10000,
-                                            step: 10,
-                                            width: 50)
-
-                            CustomFrameUnitPicker(value: $userSettings.customFrameHeightUnit)
-
-                            Spacer()
-                        }.padding()
-                    }
-
-                    GroupBox(label: Text("Origin")) {
-                        VStack(alignment: .leading, spacing: 10.0) {
-                            Picker(selection: $userSettings.customFrameOrigin, label: Text("")) {
-                                Text("Upper-Left").tag(0)
-                                Text("Lower-Left").tag(1)
-                                Text("Upper-Right").tag(2)
-                                Text("Lower-Right").tag(3)
-                            }.frame(width: 200.0)
-
-                            HStack {
-                                Text("Margin-X")
-
-                                DoubleTextField(value: $userSettings.customFrameLeft,
-                                                range: -10000 ... 10000,
-                                                step: 100,
-                                                width: 50)
-
-                                Text("pt")
-
-                                Text("Margin-Y").padding(.leading, 40)
-
-                                DoubleTextField(value: $userSettings.customFrameTop,
-                                                range: -10000 ... 10000,
-                                                step: 100,
-                                                width: 50)
-
-                                Text("pt")
-
-                                Spacer()
-                            }
-                        }.padding()
-                    }
+                    customFrameSettings
+                        .disabled(!userSettings.useCustomFrame)
                 }.padding()
             }
 
             Spacer()
         }.padding()
+    }
+
+    var customFrameSettings: some View {
+        Group {
+            GroupBox(label: Text("Size")) {
+                HStack {
+                    Text("Width")
+
+                    DoubleTextField(value: $userSettings.customFrameWidth,
+                                    range: 0 ... 10000,
+                                    step: 10,
+                                    width: 50)
+
+                    CustomFrameUnitPicker(value: $userSettings.customFrameWidthUnit)
+
+                    Text("Height").padding(.leading, 40)
+
+                    DoubleTextField(value: $userSettings.customFrameHeight,
+                                    range: 0 ... 10000,
+                                    step: 10,
+                                    width: 50)
+
+                    CustomFrameUnitPicker(value: $userSettings.customFrameHeightUnit)
+
+                    Spacer()
+                }.padding()
+            }
+
+            GroupBox(label: Text("Origin")) {
+                VStack(alignment: .leading, spacing: 10.0) {
+                    Picker(selection: $userSettings.customFrameOrigin, label: Text("")) {
+                        Text("Upper-Left").tag(0)
+                        Text("Lower-Left").tag(1)
+                        Text("Upper-Right").tag(2)
+                        Text("Lower-Right").tag(3)
+                    }.frame(width: 200.0)
+
+                    HStack {
+                        Text("Margin-X")
+
+                        DoubleTextField(value: $userSettings.customFrameLeft,
+                                        range: -10000 ... 10000,
+                                        step: 100,
+                                        width: 50)
+
+                        Text("pt")
+
+                        Text("Margin-Y").padding(.leading, 40)
+
+                        DoubleTextField(value: $userSettings.customFrameTop,
+                                        range: -10000 ... 10000,
+                                        step: 100,
+                                        width: 50)
+
+                        Text("pt")
+
+                        Spacer()
+                    }
+                }.padding()
+            }
+
+            GroupBox(label: Text("Shape")) {
+                HStack(alignment: .top, spacing: 10.0) {
+                    Toggle(isOn: $userSettings.customFramePillShape) {
+                        Text("Use pill shape (Default: off)")
+                    }
+
+                    Spacer()
+                }.padding()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
When using a custom frame, I thought that rounding the frame's corner into a pill shape could look a bit better:

<img width="233" alt="CleanShot 2022-01-27 at 14 50 43@2x" src="https://user-images.githubusercontent.com/1164565/151362905-0c95255d-6175-4dc6-a687-42295829d876.png">

<img width="190" alt="CleanShot 2022-01-27 at 14 50 33@2x" src="https://user-images.githubusercontent.com/1164565/151362913-9ef66351-2603-4916-8ebd-a02cbc58b6ee.png">

I've added an option to the custom frame settings:

<img width="1012" alt="CleanShot 2022-01-27 at 14 49 03@2x" src="https://user-images.githubusercontent.com/1164565/151362951-6b65436c-45b8-4785-a551-fbbaf9f4c4ba.png">

Also, I've disabled the custom frame settings view if custom frame is not active:

<img width="1012" alt="CleanShot 2022-01-27 at 14 49 08@2x" src="https://user-images.githubusercontent.com/1164565/151362974-7c162250-ce8a-402f-87b8-9539f2b64a5c.png">

