### PR TITLE
Add text pill indicator mode

### DIFF
--- a/src/ShowyEdge/swift/Models/InputSourceShortLabel.swift
+++ b/src/ShowyEdge/swift/Models/InputSourceShortLabel.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum InputSourceShortLabel {
+  static func make(
+    inputSourceID: String,
+    inputModeID: String,
+    localizedName: String
+  ) -> String {
+    if let label = labelForKnownID(inputSourceID) {
+      return label
+    }
+
+    if let label = labelForKnownID(inputModeID) {
+      return label
+    }
+
+    let normalizedName = localizedName.folding(
+      options: [.caseInsensitive, .diacriticInsensitive],
+      locale: .current
+    ).lowercased()
+
+    if normalizedName.contains("abc")
+      || normalizedName.contains("u.s.")
+      || normalizedName.contains("english")
+      || normalizedName.contains("british")
+    {
+      return "EN"
+    }
+
+    if let lastComponent = inputSourceID.split(separator: ".").last {
+      return shortLabel(String(lastComponent))
+    }
+
+    return shortLabel(localizedName)
+  }
+
+  private static func labelForKnownID(_ value: String) -> String? {
+    let knownPrefixes: [(String, String)] = [
+      ("com.apple.keylayout.ABC", "EN"),
+      ("com.apple.keylayout.US", "EN"),
+      ("com.apple.keylayout.British", "EN"),
+      ("com.apple.keylayout.Dvorak", "EN"),
+      ("com.apple.inputmethod.Roman", "EN"),
+      ("com.apple.keylayout.German", "DE"),
+      ("com.apple.keylayout.French", "FR"),
+      ("com.apple.keylayout.Italian", "IT"),
+      ("com.apple.keylayout.Spanish", "ES"),
+      ("com.apple.keylayout.Swedish", "SV"),
+      ("com.apple.keylayout.Portuguese", "PT"),
+      ("com.apple.keylayout.Kazakh", "KK"),
+      ("com.apple.inputmethod.Japanese", "JP"),
+      ("com.apple.inputmethod.Korean", "KO"),
+      ("com.apple.inputmethod.TCIM", "ZH"),
+      ("com.apple.inputmethod.SCIM", "ZH"),
+    ]
+
+    for (prefix, label) in knownPrefixes where value.hasPrefix(prefix) {
+      return label
+    }
+
+    return nil
+  }
+
+  private static func shortLabel(_ value: String) -> String {
+    let compact = String(value.filter { $0.isLetter || $0.isNumber })
+      .uppercased()
+
+    if compact.isEmpty {
+      return "--"
+    }
+
+    if compact.count <= 3 {
+      return compact
+    }
+
+    return String(compact.prefix(2))
+  }
+}

--- a/src/ShowyEdge/swift/Models/LanguageColor.swift
+++ b/src/ShowyEdge/swift/Models/LanguageColor.swift
@@ -4,15 +4,46 @@ class LanguageColor: Identifiable, Equatable {
   var id: String
   var inputSourceID: String
   var colors: (Color, Color, Color)
+  var textPillBackgroundColor: Color
+  var textPillForegroundColor: Color
+  var textPillLabel: String
 
-  init(_ inputSourceID: String, _ colors: (Color, Color, Color)) {
+  init(
+    _ inputSourceID: String,
+    _ colors: (Color, Color, Color),
+    textPillBackgroundColor: Color? = nil,
+    textPillForegroundColor: Color? = nil,
+    textPillLabel: String? = nil
+  ) {
     id = inputSourceID
     self.inputSourceID = inputSourceID
     self.colors = colors
+    self.textPillBackgroundColor =
+      textPillBackgroundColor
+      ?? LanguageColor.defaultTextPillBackgroundColor(colors: colors)
+    self.textPillForegroundColor = textPillForegroundColor ?? Color.white
+    self.textPillLabel =
+      textPillLabel?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+      ?? InputSourceShortLabel.make(
+        inputSourceID: inputSourceID,
+        inputModeID: "",
+        localizedName: inputSourceID
+      )
   }
 
   static func == (lhs: LanguageColor, rhs: LanguageColor) -> Bool {
     return lhs.id == rhs.id
+  }
+
+  private static func defaultTextPillBackgroundColor(colors: (Color, Color, Color)) -> Color {
+    let visibleColors = [colors.0, colors.1, colors.2].filter { color in
+      color.components.opacity > 0.01
+    }
+
+    return visibleColors.first { color in
+      let components = color.components
+      return components.red < 0.9 || components.green < 0.9 || components.blue < 0.9
+    } ?? visibleColors.first ?? Color.blue
   }
 }
 
@@ -32,14 +63,19 @@ struct LanguageColorsAppStorage {
       (UserDefaults.standard.object(forKey: key) as? [[String: String]] ?? []).forEach {
         let inputSourceID = $0["inputsourceid"] ?? ""
         if inputSourceID != "" {
+          let colors = (
+            Color(colorString: $0["color0"] ?? ""),
+            Color(colorString: $0["color1"] ?? ""),
+            Color(colorString: $0["color2"] ?? "")
+          )
+
           languageColors.append(
             LanguageColor(
               inputSourceID,
-              (
-                Color(colorString: $0["color0"] ?? ""),
-                Color(colorString: $0["color1"] ?? ""),
-                Color(colorString: $0["color2"] ?? "")
-              )
+              colors,
+              textPillBackgroundColor: $0["text_pill_background_color"].map(Color.init),
+              textPillForegroundColor: $0["text_pill_foreground_color"].map(Color.init),
+              textPillLabel: $0["text_pill_label"]
             ))
         }
       }
@@ -58,9 +94,18 @@ struct LanguageColorsAppStorage {
           "color0": hexStrings.0,
           "color1": hexStrings.1,
           "color2": hexStrings.2,
+          "text_pill_background_color": $0.textPillBackgroundColor.hexString,
+          "text_pill_foreground_color": $0.textPillForegroundColor.hexString,
+          "text_pill_label": $0.textPillLabel,
         ])
       }
       UserDefaults.standard.set(languageColors, forKey: key)
     }
+  }
+}
+
+extension String {
+  fileprivate var nonEmpty: String? {
+    isEmpty ? nil : self
   }
 }

--- a/src/ShowyEdge/swift/UserSettings.swift
+++ b/src/ShowyEdge/swift/UserSettings.swift
@@ -20,6 +20,11 @@ enum CustomFrameUnit: Int {
   case percent
 }
 
+enum IndicatorDisplayMode: String {
+  case colors
+  case textPill
+}
+
 final class UserSettings: ObservableObject {
   @AppStorage("initialOpenAtLoginRegistered") var initialOpenAtLoginRegistered = false
   @AppStorage("showAdditionalMenuItems") var showAdditionalMenuItems: Bool = false
@@ -32,7 +37,13 @@ final class UserSettings: ObservableObject {
   @AppStorage("kIndicatorOpacity2") var indicatorOpacity = 100.0
   @AppStorage("kHideInFullScreenSpace") var hideIfMenuBarIsHidden = false
   @AppStorage("kShowIndicatorBehindAppWindows") var showIndicatorBehindAppWindows = false
+  @AppStorage("kIndicatorDisplayMode") var indicatorDisplayMode = IndicatorDisplayMode.colors.rawValue
   @AppStorage("kColorsLayoutOrientation") var colorsLayoutOrientation = "horizontal"
+  @AppStorage("kIndicatorTextPillBackgroundColor") var indicatorTextPillBackgroundColor =
+    "#111827e6"
+  @AppStorage("kIndicatorTextPillForegroundColor") var indicatorTextPillForegroundColor =
+    "#ffffffff"
+  @AppStorage("kIndicatorTextPillFontSize") var indicatorTextPillFontSize = 14.0
   @AppStorage("kUseCustomFrame") var useCustomFrame = false
   @AppStorage("kFollowActiveWindow") var followActiveWindow = false
   @AppStorage("minWindowWidthToFollowActiveWindow") var minWindowWidthToFollowActiveWindow = 100.0
@@ -70,6 +81,23 @@ final class UserSettings: ObservableObject {
     return nil
   }
 
+  func customizedLanguageTextPillColor(inputSourceID: String) -> (Color, Color)? {
+    if let color = customizedLanguageColors.first(where: { $0.inputSourceID == inputSourceID }) {
+      return (color.textPillBackgroundColor, color.textPillForegroundColor)
+    }
+
+    return nil
+  }
+
+  func customizedLanguageTextPillLabel(inputSourceID: String) -> String? {
+    if let color = customizedLanguageColors.first(where: { $0.inputSourceID == inputSourceID }) {
+      let label = color.textPillLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+      return label.isEmpty ? nil : label
+    }
+
+    return nil
+  }
+
   func appendCustomizedLanguageColor(_ inputSourceID: String) {
     if inputSourceID == "" {
       return
@@ -94,6 +122,13 @@ final class UserSettings: ObservableObject {
           Color(colorString: "#ff0000ff"),
           Color(colorString: "#ff0000ff"),
           Color(colorString: "#ff0000ff")
+        ),
+        textPillBackgroundColor: Color(colorString: indicatorTextPillBackgroundColor),
+        textPillForegroundColor: Color(colorString: indicatorTextPillForegroundColor),
+        textPillLabel: InputSourceShortLabel.make(
+          inputSourceID: inputSourceID,
+          inputModeID: "",
+          localizedName: inputSourceID
         )
       )
     )

--- a/src/ShowyEdge/swift/Views/IndicatorView.swift
+++ b/src/ShowyEdge/swift/Views/IndicatorView.swift
@@ -8,24 +8,21 @@ struct IndicatorView: View {
 
   @ObservedObject var userSettings: UserSettings
   @ObservedObject private var indicatorColors = IndicatorColors.shared
+  @ObservedObject private var workspaceData = WorkspaceData.shared
 
   var body: some View {
     GeometryReader { metrics in
-      if userSettings.colorsLayoutOrientation == "horizontal" {
-        HStack(spacing: 0) {
-          Rectangle().fill(self.indicatorColors.colors.0).frame(width: metrics.size.width / 3)
-          Rectangle().fill(self.indicatorColors.colors.1).frame(width: metrics.size.width / 3)
-          Rectangle().fill(self.indicatorColors.colors.2).frame(width: metrics.size.width / 3)
-        }
+      if userSettings.indicatorDisplayMode == IndicatorDisplayMode.textPill.rawValue {
+        textPill(metrics: metrics)
       } else {
-        VStack(spacing: 0) {
-          Rectangle().fill(self.indicatorColors.colors.0).frame(height: metrics.size.height / 3)
-          Rectangle().fill(self.indicatorColors.colors.1).frame(height: metrics.size.height / 3)
-          Rectangle().fill(self.indicatorColors.colors.2).frame(height: metrics.size.height / 3)
-        }
+        colorBars(metrics: metrics)
       }
     }
-    .if(userSettings.useCustomFrame && userSettings.customFramePillShape) {
+    .if(
+      userSettings.indicatorDisplayMode == IndicatorDisplayMode.colors.rawValue
+        && userSettings.useCustomFrame
+        && userSettings.customFramePillShape
+    ) {
       $0.clipShape(Capsule())
     }
     .onReceive(NotificationCenter.default.publisher(for: openSettingsNotification)) { _ in
@@ -35,5 +32,74 @@ struct IndicatorView: View {
         }
       }
     }
+  }
+
+  @ViewBuilder
+  private func colorBars(metrics: GeometryProxy) -> some View {
+    if userSettings.colorsLayoutOrientation == "horizontal" {
+      HStack(spacing: 0) {
+        Rectangle().fill(self.indicatorColors.colors.0).frame(width: metrics.size.width / 3)
+        Rectangle().fill(self.indicatorColors.colors.1).frame(width: metrics.size.width / 3)
+        Rectangle().fill(self.indicatorColors.colors.2).frame(width: metrics.size.width / 3)
+      }
+    } else {
+      VStack(spacing: 0) {
+        Rectangle().fill(self.indicatorColors.colors.0).frame(height: metrics.size.height / 3)
+        Rectangle().fill(self.indicatorColors.colors.1).frame(height: metrics.size.height / 3)
+        Rectangle().fill(self.indicatorColors.colors.2).frame(height: metrics.size.height / 3)
+      }
+    }
+  }
+
+  private func textPill(metrics: GeometryProxy) -> some View {
+    let opacity = min(max(userSettings.indicatorOpacity / 100, 0), 1)
+    let fontSize = min(
+      max(CGFloat(userSettings.indicatorTextPillFontSize), 1),
+      max(metrics.size.height * 0.72, 1)
+    )
+
+    return ZStack {
+      Capsule()
+        .fill(textPillColors.0)
+        .opacity(opacity)
+
+      Text(currentInputSourceLabel)
+        .font(.system(size: fontSize, weight: .semibold, design: .rounded))
+        .foregroundColor(textPillColors.1)
+        .lineLimit(1)
+        .minimumScaleFactor(0.35)
+        .allowsTightening(true)
+        .padding(.horizontal, max(metrics.size.height * 0.18, 2))
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+
+  private var currentInputSourceLabel: String {
+    if let label = userSettings.customizedLanguageTextPillLabel(
+      inputSourceID: workspaceData.currentInputSourceID
+    ) {
+      return label
+    }
+
+    return InputSourceShortLabel.make(
+      inputSourceID: workspaceData.currentInputSourceID,
+      inputModeID: workspaceData.currentInputModeID,
+      localizedName: workspaceData.getInputSourceLocalizedName(
+        inputSourceID: workspaceData.currentInputSourceID
+      )
+    )
+  }
+
+  private var textPillColors: (Color, Color) {
+    if let colors = userSettings.customizedLanguageTextPillColor(
+      inputSourceID: workspaceData.currentInputSourceID
+    ) {
+      return colors
+    }
+
+    return (
+      Color(colorString: userSettings.indicatorTextPillBackgroundColor),
+      Color(colorString: userSettings.indicatorTextPillForegroundColor)
+    )
   }
 }

--- a/src/ShowyEdge/swift/Views/Settings/SettingsIndicatorView.swift
+++ b/src/ShowyEdge/swift/Views/Settings/SettingsIndicatorView.swift
@@ -5,6 +5,18 @@ struct SettingsIndicatorView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 25.0) {
+      GroupBox(label: Text("Appearance")) {
+        VStack(alignment: .leading, spacing: 12.0) {
+          Picker(selection: $userSettings.indicatorDisplayMode, label: Text("")) {
+            Text("Color stripes (Default)").tag(IndicatorDisplayMode.colors.rawValue)
+            Text("Text pill").tag(IndicatorDisplayMode.textPill.rawValue)
+          }
+          .pickerStyle(.radioGroup)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
       GroupBox(label: Text("Height")) {
         VStack {
           HStack {
@@ -64,16 +76,18 @@ struct SettingsIndicatorView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
       }
 
-      GroupBox(label: Text("Colors Layout Orientation")) {
-        VStack {
-          Picker(selection: $userSettings.colorsLayoutOrientation, label: Text("")) {
-            Text("Horizontal (Default)").tag("horizontal")
-            Text("Vertical").tag("vertical")
+      if userSettings.indicatorDisplayMode == IndicatorDisplayMode.colors.rawValue {
+        GroupBox(label: Text("Colors Layout Orientation")) {
+          VStack {
+            Picker(selection: $userSettings.colorsLayoutOrientation, label: Text("")) {
+              Text("Horizontal (Default)").tag("horizontal")
+              Text("Vertical").tag("vertical")
+            }
+            .pickerStyle(.radioGroup)
           }
-          .pickerStyle(.radioGroup)
+          .padding()
+          .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
   }

--- a/src/ShowyEdge/swift/Views/Settings/SettingsMainView.swift
+++ b/src/ShowyEdge/swift/Views/Settings/SettingsMainView.swift
@@ -7,8 +7,6 @@ struct SettingsMainView: View {
   @ObservedObject private var openAtLogin = OpenAtLogin.shared
   @ObservedObject private var workspaceData = WorkspaceData.shared
 
-  @State private var hoverLanguageColor: LanguageColor?
-
   var body: some View {
     VStack(alignment: .leading, spacing: 25.0) {
       GroupBox(label: Text("Basic")) {
@@ -53,90 +51,86 @@ struct SettingsMainView: View {
 
       GroupBox(label: Text("Color")) {
         VStack(alignment: .leading, spacing: 10.0) {
-          if $userSettings.customizedLanguageColors.count > 0 {
-            ScrollViewReader { proxy in
-              List {
+          if !userSettings.customizedLanguageColors.isEmpty {
+            ScrollView {
+              LazyVStack(alignment: .leading, spacing: 10) {
                 ForEach($userSettings.customizedLanguageColors) { $languageColor in
-                  // Make a copy to use it in onHover.
-                  // (Without copy, the program crashes with an incorrect reference when the profile is deleted.)
-                  let languageColorCopy = languageColor
+                  VStack(alignment: .leading, spacing: 8) {
+                    Text(
+                      workspaceData.getInputSourceLocalizedName(
+                        inputSourceID: languageColor.inputSourceID)
+                    )
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .if(languageColor.inputSourceID == workspaceData.currentInputSourceID) {
+                      $0.foregroundColor(.accentColor)
+                    }
 
-                  VStack(alignment: .leading) {
-                    HStack(alignment: .center, spacing: 4) {
-                      Text(
-                        workspaceData.getInputSourceLocalizedName(
-                          inputSourceID: languageColor.inputSourceID)
-                      )
-                      .padding(.trailing, 2)
-                      .fixedSize(horizontal: false, vertical: true)
-                      .if(languageColor.inputSourceID == workspaceData.currentInputSourceID) {
-                        $0.foregroundColor(.accentColor)
-                      }
-                      .frame(maxWidth: .infinity, alignment: .leading)
-                      .if(hoverLanguageColor == languageColorCopy) {
-                        $0.overlay(
-                          RoundedRectangle(cornerRadius: 2)
-                            .inset(by: -4)
-                            .stroke(
-                              Color.accentColor,
-                              lineWidth: 2
-                            )
-                        )
-                      }
+                    HStack(alignment: .center, spacing: 10) {
+                      Text(languageColor.inputSourceID)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                      HStack(alignment: .center, spacing: 4) {
-                        ColorPicker("color 1", selection: $languageColor.colors.0)
-                          .labelsHidden()
-
-                        ColorPicker("color 2", selection: $languageColor.colors.1)
-                          .labelsHidden()
-
-                        ColorPicker("color 3", selection: $languageColor.colors.2)
-                          .labelsHidden()
-
-                        Button(
-                          role: .destructive,
-                          action: {
-                            userSettings.removeCustomizedLanguageColor(
-                              languageColor.inputSourceID
-                            )
-                          },
-                          label: {
-                            Label("Delete", systemImage: "trash")
-                              .labelStyle(.iconOnly)
-                              .foregroundColor(.red)
-                          }
-                        )
-                        .padding(.leading, 10)
-                      }
-                      .padding(.leading, 10)
-                      .onHover { hovering in
-                        if hovering {
-                          hoverLanguageColor = languageColorCopy
-                        } else {
-                          if hoverLanguageColor == languageColorCopy {
-                            hoverLanguageColor = nil
-                          }
+                      Button(
+                        role: .destructive,
+                        action: {
+                          userSettings.removeCustomizedLanguageColor(
+                            languageColor.inputSourceID
+                          )
+                        },
+                        label: {
+                          Label("Delete", systemImage: "trash")
+                            .labelStyle(.iconOnly)
+                            .foregroundColor(.red)
                         }
+                      )
+                    }
+
+                    colorRow(label: "Stripes") {
+                      HStack(alignment: .center, spacing: 4) {
+                        ColorPicker("stripe color 1", selection: $languageColor.colors.0)
+                          .labelsHidden()
+
+                        ColorPicker("stripe color 2", selection: $languageColor.colors.1)
+                          .labelsHidden()
+
+                        ColorPicker("stripe color 3", selection: $languageColor.colors.2)
+                          .labelsHidden()
                       }
                     }
 
-                    Text(languageColor.inputSourceID)
-                      .font(.caption)
-                      .fixedSize(horizontal: false, vertical: true)
+                    colorRow(label: "Pill") {
+                      HStack(alignment: .center, spacing: 4) {
+                        ColorPicker(
+                          "Pill background",
+                          selection: $languageColor.textPillBackgroundColor
+                        )
+                        .labelsHidden()
+
+                        ColorPicker(
+                          "Pill text",
+                          selection: $languageColor.textPillForegroundColor
+                        )
+                        .labelsHidden()
+                      }
+                    }
+
+                    colorRow(label: "Text") {
+                      TextField("", text: $languageColor.textPillLabel)
+                        .textFieldStyle(.roundedBorder)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 70)
+                    }
                   }
+                  .padding(.vertical, 6)
+
+                  Divider()
                 }
               }
-              .frame(height: 200)
-              .onChange(of: userSettings.customizedLanguageColors.count) { _ in
-                if let first = userSettings.customizedLanguageColors.first {
-                  withAnimation {
-                    // Reset position when customizedLanguageColors is added.
-                    proxy.scrollTo(first.id, anchor: .top)
-                  }
-                }
-              }
+              .padding(.trailing, 8)
             }
+            .frame(height: 260)
           } else {
             Text(currentInputSourceLocalizedName)
               .foregroundColor(.gray)
@@ -159,6 +153,22 @@ struct SettingsMainView: View {
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
       }
+    }
+  }
+
+  private func colorRow<Controls: View>(
+    label: String,
+    @ViewBuilder controls: () -> Controls
+  ) -> some View {
+    HStack(alignment: .center, spacing: 10) {
+      Text(label)
+        .font(.caption)
+        .foregroundColor(.gray)
+        .frame(width: 70, alignment: .leading)
+
+      Spacer(minLength: 20)
+
+      controls()
     }
   }
 }


### PR DESCRIPTION
## Summary

This is a proposal for a new text-based indicator appearance.

The existing color stripes remain the default behavior. This PR adds an optional
`Text pill` mode that renders the current input source as a small capsule with a
customizable short text label.

## Changes

- Add a `Text pill` appearance mode for the indicator.
- Add per-input-source pill background and text colors.
- Add a per-input-source text label setting, so the pill text can be customized.
- Keep the `Indicator` settings page focused on choosing the appearance mode.
- Move pill color and text customization into the existing `Main` color settings.
- Replace the color settings `List` with a `ScrollView`/`LazyVStack` to avoid scroll position jumps while editing.

## Notes

This is intentionally a UI/UX proposal. I am happy to adjust the implementation
or split the changes differently if there is a preferred project direction.

## Screenshots

Color settings:

<img width="586" height="237" alt="screen-1-settings" src="https://github.com/user-attachments/assets/6400b2fe-bcbd-4ddd-ae23-a31805e11b52" />

Indicator appearance:

<img width="601" height="232" alt="screen-2-settings" src="https://github.com/user-attachments/assets/13210e87-3ea8-48d0-bb54-4e7d5830aca6" />

Desktop indicator:

<img width="278" height="264" alt="screen-3-desktop" src="https://github.com/user-attachments/assets/db95cae8-ee97-48ed-898c-1458ce19c7ea" />

## Validation

- `git diff --check`
- `make -C src`
